### PR TITLE
fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 notifications:
   email: false
 env:
@@ -10,6 +11,7 @@ python:
   - pypy
   - 3.2
   - 3.3
+  - 3.4
 install:
   - pip install -r requirements.txt
   - pip install -r tests/requirements.txt

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ rednose
 nose-cov
 codecov
 ddt
+six

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,6 +2,7 @@ import os
 import time
 import unittest
 from ddt import ddt, data
+from six import u
 from datetime import datetime, timedelta
 
 from timestring import Date
@@ -388,14 +389,15 @@ class timestringTests(unittest.TestCase):
           (6400005, "six million four hundred thousand five"),
           (123456789012, "one hundred twenty three billion four hundred fifty six million seven hundred eighty nine thousand twelve"),
           (4000000000000000000000000000000000, "four decillion"))
-    def test_string_to_number(self, (equals, string)):
+    def test_string_to_number(self, data):
+        (equals, string) = data
         self.assertEqual(text2num(string), equals)
-        self.assertEqual(text2num(unicode(string)), equals)
+        self.assertEqual(text2num(u(string)), equals)
 
     def test_plus(self):
-        date = Date('now') + '10 seconds'
-        now = Date('now')
-        self.assertEqual(now.second + 10, date.second)
+        date1 = Date("october 18, 2013 10:04:32 PM")
+        date2 = date1 + "10 seconds"
+        self.assertEqual(date1.second + 10, date2.second)
 
 
 def main():


### PR DESCRIPTION
- use six to handle unicode python 3 errors
- intermittent failures by using Date('now') which fails from :50 to :59
- add python 3.4 to travis.yml